### PR TITLE
Feature/chapter6

### DIFF
--- a/changeLog.txt
+++ b/changeLog.txt
@@ -7,6 +7,7 @@ develop
 - 2017-12-15                                                -
 -------------------------------------------------------------
 .: Redirect after POST and show all items in template (Chapter 5)
+.: Make functional_tests an app - use LiveServerTestCase (Chapter 6)
 
 -------------------------------------------------------------
 - 2017-12-14                                                -

--- a/changeLog.txt
+++ b/changeLog.txt
@@ -8,6 +8,7 @@ develop
 -------------------------------------------------------------
 .: Redirect after POST and show all items in template (Chapter 5)
 .: Make functional_tests an app - use LiveServerTestCase (Chapter 6)
+.: Avoid "voodoo" sleeps (Chapter 6)
 
 -------------------------------------------------------------
 - 2017-12-14                                                -

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -1,9 +1,9 @@
+from django.test import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 import time
-import unittest
 
-class NewVisitorTest(unittest.TestCase):
+class NewVisitorTest(LiveServerTestCase):
 
     def setUp(self):
         self.browser = webdriver.Firefox()
@@ -19,7 +19,7 @@ class NewVisitorTest(unittest.TestCase):
     def test_can_start_a_list_and_retrieve_it_later(self):
         # Michelle has heard about a cool new online to-do app. She goes
         # to check out its homepage
-        self.browser.get('http://localhost:8000')
+        self.browser.get(self.live_server_url)
 
         # She notices the page title and header mention to-do lists
         self.assertIn('To-Do', self.browser.title)
@@ -62,7 +62,3 @@ class NewVisitorTest(unittest.TestCase):
         # She visits that URL - her to-do list is still there
 
         # Satisfies, she goes back to sleep
-
-
-if __name__ == '__main__':
-    unittest.main(warnings='ignore')

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -1,7 +1,10 @@
 from django.test import LiveServerTestCase
+from selenium.common.exceptions import WebDriverException
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 import time
+
+MAX_WAIT = 10
 
 class NewVisitorTest(LiveServerTestCase):
 
@@ -11,10 +14,18 @@ class NewVisitorTest(LiveServerTestCase):
     def tearDown(self):
         self.browser.quit()
 
-    def check_for_row_in_list_table(self, row_text):
-        table = self.browser.find_element_by_id('id_list_table')
-        rows = table.find_elements_by_tag_name('tr')
-        self.assertIn(row_text, [row.text for row in rows])
+    def wait_for_row_in_list_table(self, row_text):
+        start_time = time.time()
+        while True:
+            try:
+                table = self.browser.find_element_by_id('id_list_table')
+                rows = table.find_elements_by_tag_name('tr')
+                self.assertIn(row_text, [row.text for row in rows])
+                return
+            except (AssertionError, WebDriverException) as e:
+                if time.time() - start_time > MAX_WAIT:
+                    raise e
+                time.sleep(0.5)
 
     def test_can_start_a_list_and_retrieve_it_later(self):
         # Michelle has heard about a cool new online to-do app. She goes
@@ -40,19 +51,17 @@ class NewVisitorTest(LiveServerTestCase):
         # When she hits enter, the page updates, and now the page lists
         # "1: Buy peacock feathers" as an item in a to-do list
         inputbox.send_keys(Keys.ENTER)
-        time.sleep(1)
-        self.check_for_row_in_list_table('1: Buy peacock feathers')
+        self.wait_for_row_in_list_table('1: Buy peacock feathers')
 
         # Theare is still a text box inviting her to add another item. She
         # enters "Use peacock feathers to make a fly" (Michelle is very methodical)
         inputbox = self.browser.find_element_by_id('id_new_item')
         inputbox.send_keys('Use peacock feathers to make a fly')
         inputbox.send_keys(Keys.ENTER)
-        time.sleep(1)
 
         # The page updates again, and now shows both items on her list
-        self.check_for_row_in_list_table('1: Buy peacock feathers')
-        self.check_for_row_in_list_table('2: Use peacock feathers to make a fly')
+        self.wait_for_row_in_list_table('1: Buy peacock feathers')
+        self.wait_for_row_in_list_table('2: Use peacock feathers to make a fly')
 
         # Michelle wonders whether the site will remember her list. Then she sees
         # that the site has generated a unique URL for her -- there is some


### PR DESCRIPTION
# Testing "Best Practices" Applied in this Chapter
**Ensuring test isolation and managing global state**
Different tests shouldn’t affect one another. This means we need to reset any permanent state at the end of each test. Django’s test runner helps us do this by creating a test database, which it wipes clean in between each test. (See also [chapter_purist_unit_tests].)

**Avoid "voodoo" sleeps**
Whenever we need to wait for something to load, it’s always tempting to throw in a quick-and-dirty time.sleep. But the problem is that the length of time we wait is always a bit of a shot in the dark, either too short and vulnerable to spurious failures, or too long and it’ll slow down our test runs. Prefer a retry loop that polls our app and moves on as soon as possible.

**Don’t rely on Selenium’s implicit waits**
Selenium does theoretically do some "implicit" waits, but the implementation varies between browsers, and at the time of writing was highly unreliable in the Selenium 3 Firefox driver. "Explicit is better than implict", as the Zen of Python says, so prefer explicit waits.