### PR TITLE
.: Notes and template config files for provisioning (Chapter 10)

### DIFF
--- a/changeLog.txt
+++ b/changeLog.txt
@@ -10,6 +10,7 @@ develop
 .: Modify .gitignore
 .: Add gunicorn to virtualenv requirements (Chapter 10)
 .: Set DEBUG = false and add TEMPLATE_DEBUG = DEBUG in setting.py (Chapter 10)
+.: Notes and template config files for provisioning (Chapter 10)
 
 -------------------------------------------------------------
 - 2017-12-20                                                -

--- a/deploy_tools/gunicorn-systemd.template.service
+++ b/deploy_tools/gunicorn-systemd.template.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Gunicorn server for SITENAME
+
+[Service]
+Restart=on-failure
+User=elspeth
+WorkingDirectory=/home/elspeth/sites/SITENAME/source
+ExecStart=/home/elspeth/sites/SITENAME/virtualenv/bin/gunicorn \
+    --bind unix:/tmp/SITENAME.socket \
+    superlists.wsgi:application
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy_tools/nginx.template.conf
+++ b/deploy_tools/nginx.template.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name SITENAME;
+
+    location /static {
+        alias /home/elspeth/sites/SITENAME/static;
+    }
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_pass http://unix:/tmp/SITENAME.socket;
+    }
+}

--- a/deploy_tools/provisioning_notes.md
+++ b/deploy_tools/provisioning_notes.md
@@ -1,0 +1,36 @@
+Provisioning a new site
+=======================
+
+## Required packages:
+
+* nginx
+* Python 3.6
+* virtualenv + pip
+* Git
+
+eg, on Ubuntu:
+
+    sudo add-apt-repository ppa:fkrull/deadsnakes
+    sudo apt-get update
+    sudo apt-get install nginx git python36 python3.6-venv
+
+## Nginx Virtual Host config
+
+* see nginx.template.conf
+* replace SITENAME with, e.g., staging.my-domain.com
+
+## Systemd service
+
+* see gunicorn-systemd.template.service
+* replace SITENAME with, e.g., staging.my-domain.com
+
+## Folder structure:
+Assume we have a user account at /home/username
+
+/home/username
+└── sites
+    └── SITENAME
+         ├── database
+         ├── source
+         ├── static
+         └── virtualenv


### PR DESCRIPTION
# Production-Readiness for Server Deployments
A few things to think about when trying to build a production-ready server environment:

**Don’t use the Django dev server in production**
Something like Gunicorn or uWSGI is a better tool for running Django; they will let you run multiple workers, for example.

**Don’t use Django to serve your static files**
There’s no point in using a Python process to do the simple job of serving static files. Nginx can do it, but so can other web servers like Apache or uWSGI.

**Check your settings.py for dev-only settings**
DEBUG=True and ALLOWED_HOSTS are the two we looked at, but you will probably have others (we’ll see more when we start to send emails from the server).

**Security**
A serious discussion of server security is beyond the scope of this book, and I’d warn against running your own servers without learning a good bit more about it. (One reason people choose to use a PaaS to host their code is that it means a slightly fewer security issues to worry about.) If you’d like a place to start, here’s as good a place as any: [My first 5 minutes on a server](https://plusbryan.com/my-first-5-minutes-on-a-server-or-essential-security-for-linux-servers). I can definitely recommend the eye-opening experience of installing fail2ban and watching its logfiles to see just how quickly it picks up on random drive-by attempts to brute force your SSH login. The internet is a dangerous place!